### PR TITLE
Add Laravel 13 & PHP 8.5 to testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,16 +7,16 @@ on:
 jobs:
   php-tests:
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
-        php: [8.3, 8.4]
-        laravel: [12.*]
+        php: [8.3, 8.4, 8.5]
+        laravel: [12.*, 13.*]
         statamic: [^6.0]
         os: [ubuntu-latest]
-        
+
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.statamic }} - ubuntu-latest
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This pull request adds Laravel 13 and PHP 8.5 to the testing matrix.